### PR TITLE
Automate GitHub Pages deployment for typescript-port branch

### DIFF
--- a/.github/workflows/deploy-typescript-port.yml
+++ b/.github/workflows/deploy-typescript-port.yml
@@ -1,0 +1,38 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [typescript-port]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add workflow that builds and deploys `dist` to GitHub Pages on pushes to `typescript-port`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d1102fa483208ef2237bba5ad3b2