### PR TITLE
Use ticker delta time for update

### DIFF
--- a/ts/game/Game.ts
+++ b/ts/game/Game.ts
@@ -2,7 +2,6 @@ import * as PIXI from 'pixi.js';
 import { Camera } from './Camera.js';
 import { FontManager } from './FontManager.js';
 import { Input } from './Input.js';
-import { Timer } from './Timer.js';
 import { TextureManager } from './TextureManager.js';
 import { Level } from './level/Level.js';
 
@@ -10,7 +9,6 @@ export class Game {
   level: Level | null = null;
   paused = false;
   private levelOrder: string[] = [];
-  private frameTimer = new Timer();
   private keySprite: PIXI.Sprite = new PIXI.Sprite(TextureManager.KEY);
 
   constructor(levels: string[], private world: PIXI.Container) {
@@ -27,7 +25,6 @@ export class Game {
 
   openLevel(level: Level) {
     this.level = level;
-    this.frameTimer.restart();
     Camera.focus = level.player.pos;
     Camera.pixelsPerUnit = 40;
   }
@@ -37,9 +34,9 @@ export class Game {
     this.level = null;
   }
 
-  update() {
+  update(dt: number) {
     if (!this.level) return;
-    const dt = Math.min(this.frameTimer.tick().inSecs(), 0.1);
+    dt = Math.min(dt, 0.1);
     if (this.paused) return;
     this.level.update(dt);
     if (this.level.didWin) {

--- a/ts/game/Main.ts
+++ b/ts/game/Main.ts
@@ -30,7 +30,8 @@ const texts = msgs.map(m => new PIXI.Text(m, FontManager.DISPLAY));
 texts.forEach(t => { t.anchor.set(0.5); t.y = Camera.height / 2; });
 
 app.ticker.add(() => {
-  game.update();
+  const dt = Math.min(app.ticker.deltaMS / 1000, 0.1);
+  game.update(dt);
   game.render(ui);
   if (instructions) {
     const secs = instTimer.elapsed().inSecs();


### PR DESCRIPTION
## Summary
- Use PIXI ticker's delta to drive the game update loop
- Remove custom frame timer to ensure consistent movement speed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d53dc02883208473c65d538de8a0